### PR TITLE
Remove skip-provider-button=true

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -74,7 +74,6 @@ spec:
           - --pass-access-token=true
           - --scope=user:full
           - '-openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
-          - --skip-provider-button=true
           - --cookie-secure=true
           - --cookie-expire=12h0m0s
           - --cookie-refresh=8h0m0s


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/14269

after the timeout we get a 404 or 403 error, when trying to login by click `Log in with OpenShift`. but we have configured `skip-provider-button=true` in oauth-proxy so that it tries in many times to redirect and finally it fails. You will see this page
<img width="910" alt="image" src="https://user-images.githubusercontent.com/7711311/129166914-d7e2652c-593d-4672-9293-4d27d748e004.png">

With this fix, the oauth-proxy can do session cookie cleanup. so that we can login to ACM console again.

Here is reproduce steps - https://github.com/open-cluster-management/backlog/issues/8863#issuecomment-876998566
or simply input this url `https://oauth-openshift.apps.obs-china-aws-4616-mmd2q.dev05.red-chesterfield.com/oauth/authorize?approval_prompt=force&client_id=multicloudingress&redirect_uri=https://multicloud-console.apps.obs-china-aws-4616-mmd2q.dev05.red-chesterfield.com/oauth/callback&response_type=code&scope=user:full&state=5343f00138815f652cbd4a2800ffaa74:/oauth/start?rd=%2F` with replace `apps.obs-china-aws-4616-mmd2q.dev05.red-chesterfield.com` with your name.

Signed-off-by: clyang82 <chuyang@redhat.com>