### PR TITLE
Revert "Remove skip-provider-button=true"

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -74,6 +74,7 @@ spec:
           - --pass-access-token=true
           - --scope=user:full
           - '-openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
+          - --skip-provider-button=true
           - --cookie-secure=true
           - --cookie-expire=12h0m0s
           - --cookie-refresh=8h0m0s


### PR DESCRIPTION
Reverts open-cluster-management/management-ingress-chart#112

I found that each login redirects to `Log in with OpenShift` and then go to ACM login with this fix. The behaviour is not my desired behaviour. so rollback the previous fix to try to fix in `oauth-proxy` side.
